### PR TITLE
Bugfix to solve problems with special characters > 128 in values (e.g. 'ä')

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/UriUtil.java
+++ b/src/main/java/com/damnhandy/uri/template/UriUtil.java
@@ -104,7 +104,8 @@ public final class UriUtil
          for (int i = 0; i < source.length; i++)
          {
             byte c = source[i];
-            if (chars.get(c) || c <= 0x20)
+            // fixed unsigned problem
+            if (chars.get(c & 0xff) || c <= 0x20)
             {
                out.write('%');
                char hex1 = Character.toUpperCase(Character.forDigit((c >> 4) & 0xF, 16));

--- a/src/test/java/com/damnhandy/uri/template/TestCreateUriTemplate.java
+++ b/src/test/java/com/damnhandy/uri/template/TestCreateUriTemplate.java
@@ -3,12 +3,11 @@
  */
 package com.damnhandy.uri.template;
 
+import junit.framework.Assert;
+import org.junit.Test;
+
 import java.util.Map;
 import java.util.Map.Entry;
-
-import junit.framework.Assert;
-
-import org.junit.Test;
 
 /**
  * Simple tests to validate the UriTemplate API.
@@ -28,7 +27,7 @@ public class TestCreateUriTemplate
       
       UriTemplate child = UriTemplate.fromTemplate(base)
                                      .append("/things/{thingId}")
-                                     .set("thingId","12345");
+                                     .set("thingId","123öä");
       
       
       Assert.assertEquals(3, child.getValues().size());
@@ -38,7 +37,7 @@ public class TestCreateUriTemplate
          Assert.assertTrue(childValues.containsKey(e.getKey()));
          Assert.assertEquals(e.getValue(), childValues.get(e.getKey()));
       }
-      Assert.assertEquals("http://myhost/v1/damnhandy/things/12345", child.expand());
+      Assert.assertEquals("http://myhost/v1/damnhandy/things/123%C3%B6%C3%A4", child.expand());
    }
    
    


### PR DESCRIPTION
If a special character with a byte > 128 (ä for example) is used in a
value, the numeric value is < 0 and the bit set throws an Exception.

See java.io.ByteArrayInputStream#read for example.
