### PR TITLE
Escaped the special characters '|' and '\' when used as query parameter.

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/UriUtil.java
+++ b/src/main/java/com/damnhandy/uri/template/UriUtil.java
@@ -39,8 +39,10 @@ public final class UriUtil
       }
       RESERVED.set(' ');
       RESERVED.set('%');
+      RESERVED.set('|');
+      RESERVED.set('\\');
 
-      for (int i = 0; i < SUB_DELIMS_CHARS.length; i++)
+       for (int i = 0; i < SUB_DELIMS_CHARS.length; i++)
       {
          RESERVED.set(SUB_DELIMS_CHARS[i]);
       }

--- a/src/test/java/com/damnhandy/uri/template/TestCreateUriTemplate.java
+++ b/src/test/java/com/damnhandy/uri/template/TestCreateUriTemplate.java
@@ -27,7 +27,7 @@ public class TestCreateUriTemplate
       
       UriTemplate child = UriTemplate.fromTemplate(base)
                                      .append("/things/{thingId}")
-                                     .set("thingId","123öä");
+                                     .set("thingId","123öä|\\");
       
       
       Assert.assertEquals(3, child.getValues().size());
@@ -37,7 +37,7 @@ public class TestCreateUriTemplate
          Assert.assertTrue(childValues.containsKey(e.getKey()));
          Assert.assertEquals(e.getValue(), childValues.get(e.getKey()));
       }
-      Assert.assertEquals("http://myhost/v1/damnhandy/things/123%C3%B6%C3%A4", child.expand());
+      Assert.assertEquals("http://myhost/v1/damnhandy/things/123%C3%B6%C3%A4%7C%5C", child.expand());
    }
    
    


### PR DESCRIPTION
Hi, 

i found some more not escaped characters in UriUtils :-) 

Greetings, Björn
