### PR TITLE
Refactored the uri encoding code to use white lists instead black lists....

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/UriTemplate.java
+++ b/src/main/java/com/damnhandy/uri/template/UriTemplate.java
@@ -3,14 +3,14 @@
  */
 package com.damnhandy.uri.template;
 
+import com.damnhandy.uri.template.impl.RFC6570UriTemplate;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.BitSet;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.damnhandy.uri.template.impl.RFC6570UriTemplate;
 
 /**
  * <p>
@@ -51,7 +51,7 @@ import com.damnhandy.uri.template.impl.RFC6570UriTemplate;
 public abstract class UriTemplate
 {
    public static enum Encoding {
-      U, UR;
+      U, UR,UF;
    }
    
    public static final String DEFAULT_SEPARATOR = ",";

--- a/src/main/java/com/damnhandy/uri/template/UriUtil.java
+++ b/src/main/java/com/damnhandy/uri/template/UriUtil.java
@@ -4,128 +4,152 @@
 package com.damnhandy.uri.template;
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.BitSet;
 
-import com.damnhandy.uri.template.impl.UriEncodingException;
-
 /**
  * <p>
- * A light-weight utility class for applying encoding to values that are applied to 
- * expression values. 
+ * A light-weight utility class for applying encoding to values that are applied to
+ * expression values.
  * </p>
- * 
+ *
  * @author <a href="ryan@damnhandy.com">Ryan J. McDonough</a>
  * @version $Revision: 1.1 $
  */
-public final class UriUtil
-{
-   static final char[] GENERAL_DELIM_CHARS = {':', '/', ',', '?', '#', '[', ']', '@'};
+public final class UriUtil {
+    private static final BitSet GENERAL_ALLOWED_CHARS = new BitSet();
 
-   static final char[] SUB_DELIMS_CHARS = {'!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', '<', '>', '{','}'};
+    private static final BitSet FRAGMENT_ALLOWED_CHARS = new BitSet();
 
-   private static final BitSet RESERVED;
+    private static final BitSet RESERVED_ALLOWED_CHARS = new BitSet();
 
-   private static final BitSet ESCAPE_CHARS;
+    static {
+        String alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        String digit = "0123456789";
 
-   static
-   {
+        /**
+         * The unreserved chars.
+         *
+         * unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+         */
+        String unreserved = alpha + digit + "-._~";
 
-      RESERVED = new BitSet();
-      for (int i = 0; i < GENERAL_DELIM_CHARS.length; i++)
-      {
-         RESERVED.set(GENERAL_DELIM_CHARS[i]);
-      }
-      RESERVED.set(' ');
-      RESERVED.set('%');
-      RESERVED.set('|');
-      RESERVED.set('\\');
+        /**
+         * The general delimiters.
+         *
+         * gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+         */
+        String gendelims = ":/?#[]@";
 
-       for (int i = 0; i < SUB_DELIMS_CHARS.length; i++)
-      {
-         RESERVED.set(SUB_DELIMS_CHARS[i]);
-      }
+        /**
+         * The sub delimiters.
+         *
+         * sub-delims     = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+         */
+        String subdelims = "!$&'()*+,;=";
 
-      ESCAPE_CHARS = new BitSet();
-      ESCAPE_CHARS.set('<');
-      ESCAPE_CHARS.set('>');
-      ESCAPE_CHARS.set('%');
-      ESCAPE_CHARS.set('\"');
-      ESCAPE_CHARS.set('{');
-      ESCAPE_CHARS.set('}');
-      ESCAPE_CHARS.set('|');
-      ESCAPE_CHARS.set('\\');
-      ESCAPE_CHARS.set('^');
-      ESCAPE_CHARS.set('[');
-      ESCAPE_CHARS.set(']');
-      ESCAPE_CHARS.set('`');
-   }
+        /**
+         * The reserved chars in URI spec.
+         *
+         * reserved      = gen-delims / sub-delims
+         */
+        String reserved = subdelims + gendelims;
 
-   private UriUtil()
-   {
 
-   }
+        /**
+         * Allowed chars in Fragments (#).
+         * See: http://tools.ietf.org/html/rfc3986#appendix-A
+         *
+         * The definition in http://tools.ietf.org/html/rfc6570#section-3.2.1 (URI-Template-RFC) is not correct!
+         * Not all characters(#[]) in GEN_DELIM are allowed here!
+         *
+         * fragment    = *( pchar / "/" / "?" )
+         * pchar       = unreserved / sub-delims / ":" / "@"
+         */
+         String fragment = unreserved+subdelims+":@/?";
 
-   /**
-    * 
-    * 
-    * @param source
-    * @return
-    */
-   public static String encodeFragment(String sourceValue)
-   {
-      return encode(sourceValue, ESCAPE_CHARS);
-   }
+        add(GENERAL_ALLOWED_CHARS, unreserved);
+        add(FRAGMENT_ALLOWED_CHARS, fragment);
 
-   /**
-    * 
-    * 
-    * @param source
-    * @return
-    */
-   public static String encode(String sourceValue)
-   {
-      return encode(sourceValue, RESERVED);
-   }
+        /**
+         * This is a special uri encoding for Uri-Templates, allowing Reserved and Unreserved chars.
+         */
+        add(RESERVED_ALLOWED_CHARS, unreserved);
+        add(RESERVED_ALLOWED_CHARS, reserved);
+    }
 
-   /**
-    * 
-    * 
-    * @param soureValue
-    * @param chars
-    * @return
-    * @throws UriEncodingException
-    */
-   private static String encode(String sourceValue, BitSet chars) throws UriEncodingException
-   {
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      try
-      {
-         byte[] source = sourceValue.getBytes(Charset.forName("UTF-8"));
-         for (int i = 0; i < source.length; i++)
-         {
+    private static void add(BitSet destination, String toAdd) {
+
+        for (char character : toAdd.toCharArray()) {
+            if (character >= 127) {
+                throw new IllegalArgumentException("Bitset only works correct with one "
+                        + "byte");
+            }
+            destination.set(character);
+        }
+    }
+
+    private UriUtil() {
+
+    }
+
+    /**
+     * Encodes fragments, allowing only the characters defined in uri fragments(http://tools.ietf
+     * .org/html/rfc3986#appendix-A). This are a few less then in the reserved expression.
+     *
+     * @param sourceValue should not contain a PCT encoded string.
+     * @return the encoded value
+     */
+    public static String encodeFragment(String sourceValue) {
+
+        return encode(sourceValue, FRAGMENT_ALLOWED_CHARS);
+    }
+
+    /**
+     * Encodes the reserved expression, allowing all reserved and unreserved characters.
+     *
+     * @param sourceValue should not contain a PCT encoded string.
+     * @return the encoded value
+     */
+    public static String encodeReserved(String sourceValue) {
+
+        return encode(sourceValue, RESERVED_ALLOWED_CHARS);
+    }
+
+    /**
+     * Encodes general uri expressions, allowing only unreserved characters.
+     *
+     * @param sourceValue should not contain a PCT encoded string.
+     * @return the encoded value
+     */
+    public static String encode(String sourceValue) {
+
+        return encode(sourceValue, GENERAL_ALLOWED_CHARS);
+    }
+
+    /**
+     * Uses a white list to encode all characters that are not contained in this list.
+     */
+    private static String encode(String sourceValue, BitSet allowedCharacters) {
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(sourceValue.length());
+        Charset utf8 = Charset.forName("UTF-8");
+        byte[] source = sourceValue.getBytes(utf8);
+        for (int i = 0; i < source.length; i++) {
             byte c = source[i];
             // fixed unsigned problem
-            if (chars.get(c & 0xff) || c <= 0x20)
-            {
-               out.write('%');
-               char hex1 = Character.toUpperCase(Character.forDigit((c >> 4) & 0xF, 16));
-               char hex2 = Character.toUpperCase(Character.forDigit(c & 0xF, 16));
-               out.write(hex1);
-               out.write(hex2);
+            if (allowedCharacters.get(c & 0xff)) {
+                out.write(c);
+
+            } else {
+                out.write('%');
+                char hex1 = Character.toUpperCase(Character.forDigit((c >> 4) & 0xF, 16));
+                char hex2 = Character.toUpperCase(Character.forDigit(c & 0xF, 16));
+                out.write(hex1);
+                out.write(hex2);
             }
-            else
-            {
-               out.write(c);
-            }
-         }
-         return new String(out.toByteArray(), "UTF-8");
-      }
-      catch (UnsupportedEncodingException e)
-      {
-         throw new UriEncodingException(e);
-      }
-   }
+        }
+        return new String(out.toByteArray(), utf8);
+    }
 
 }

--- a/src/main/java/com/damnhandy/uri/template/impl/Operator.java
+++ b/src/main/java/com/damnhandy/uri/template/impl/Operator.java
@@ -39,7 +39,7 @@ public enum Operator {
    MATRIX      (";", ";",                true,  "",  Encoding.U), 
    QUERY       ("?", "&",                true,  "=", Encoding.U), 
    CONTINUATION("&", "&",                true,  "=", Encoding.U),
-   FRAGMENT    ("#", DEFAULT_SEPARATOR,  false, "",  Encoding.UR);
+   FRAGMENT    ("#", DEFAULT_SEPARATOR,  false, "",  Encoding.UF);
 
    
    /**

--- a/src/main/java/com/damnhandy/uri/template/impl/RFC6570UriTemplate.java
+++ b/src/main/java/com/damnhandy/uri/template/impl/RFC6570UriTemplate.java
@@ -3,6 +3,10 @@
  */
 package com.damnhandy.uri.template.impl;
 
+import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.UriUtil;
+import com.damnhandy.uri.template.VarExploder;
+
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,10 +17,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.damnhandy.uri.template.UriTemplate;
-import com.damnhandy.uri.template.UriUtil;
-import com.damnhandy.uri.template.VarExploder;
 
 /**
  * A {@link UriTemplate} implementation that supports <a href="http://tools.ietf.org/html/rfc6570">RFC6570</a>
@@ -397,14 +397,13 @@ public final class RFC6570UriTemplate extends UriTemplate
          }
       }
 
-      if (operator.getEncoding() == Encoding.UR)
-      {
-         expanded = UriUtil.encodeFragment(variable);
-      }
-      else
-      {
-         expanded = UriUtil.encode(variable);
-      }
+       if (operator.getEncoding() == Encoding.UR) {
+           expanded = UriUtil.encodeReserved(variable);
+       } else if (operator.getEncoding() == Encoding.UF) {
+           expanded = UriUtil.encodeFragment(variable);
+       } else {
+           expanded = UriUtil.encode(variable);
+       }
 
       if (operator.isNamed())
       {

--- a/src/test/java/com/damnhandy/uri/template/UriUtilTest.java
+++ b/src/test/java/com/damnhandy/uri/template/UriUtilTest.java
@@ -1,0 +1,103 @@
+package com.damnhandy.uri.template;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class UriUtilTest {
+
+    private static final String ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final String DIGIT = "0123456789";
+    private static final String UNRESERVED = ALPHA + DIGIT + "-._~";
+    private static final String SUBDELIMS = "!$&'()*+,;=";
+    private static final String GENDELIMS = ":/?#[]@";
+
+
+    private void validateFragment(String excpected, String input){
+        assertEquals(excpected, UriUtil.encodeFragment(input));
+
+    }
+    private void validate(String excpected, String input){
+        assertEquals(excpected, UriUtil.encode(input));
+
+    }
+
+    private void validateReserved(String excpected, String input){
+        assertEquals(excpected, UriUtil.encodeReserved(input));
+
+    }
+    @Test
+    public void generalNothingToEncode() throws Exception {
+        validate(UNRESERVED, UNRESERVED);
+
+    }
+
+    @Test
+    public void fragmentNothingToEncode() throws Exception {
+        validateFragment(UNRESERVED+SUBDELIMS+"/?:@", UNRESERVED+SUBDELIMS+"/?:@");
+    }
+
+    @Test
+    public void reservedNothingToEncode() throws Exception {
+        validateReserved(UNRESERVED+SUBDELIMS+GENDELIMS, UNRESERVED+SUBDELIMS+GENDELIMS);
+    }
+
+    @Test
+    public void fragmentWithCharsToEncodeInFragmentButNotInReserved() throws Exception {
+        validateFragment("%23%5B%5D", "#[]");
+
+    }
+
+    @Test
+    public void fragmentWithSomeCharsToEncode() throws Exception {
+        validateFragment("%C3%A4%C3%B6", "äö");
+
+    }
+
+    @Test
+    public void reservedWithSomeCharsToEncode() throws Exception {
+        validateReserved("%C3%A4%C3%B6", "äö");
+
+    }
+
+
+    @Test
+    public void generalWithSomeCharsToEncode() throws Exception {
+
+        assertEquals("XX%C3%A4%22", UriUtil.encodeFragment("XXä\""));
+    }
+
+    @Test
+    public void exoticHighValueCharacterEncoding() throws Exception {
+        // this is the '蚠'
+        assertEquals("%E8%9A%A0", UriUtil.encodeFragment(Character.valueOf((char) 100000).toString()));
+    }
+
+    /**
+     * The list of allowed chars is build in a different way then the string in production code!
+     */
+    @Test
+    public void allowedUnreservedCharacterEncoding() throws Exception {
+        ArrayList<Character> UNRESERVED = new ArrayList<Character>();
+        for (int i = 'a'; i <= 'z'; i++) {
+            UNRESERVED.add(new Character((char) i));
+        }
+        for (int i = 'A'; i <= 'Z'; i++) {
+            UNRESERVED.add(new Character((char) i));
+        }
+        for (int i = '0'; i <= '9'; i++) {
+            UNRESERVED.add(new Character((char) i));
+        }
+        UNRESERVED.add('-');
+        UNRESERVED.add('.');
+        UNRESERVED.add('_');
+        UNRESERVED.add('~');
+
+        for (Character character: UNRESERVED){
+            assertEquals(character.toString(), UriUtil.encodeFragment(character.toString()));
+
+        }
+    }
+}


### PR DESCRIPTION
Refactored the uri encoding code to use white lists instead black lists. The characters in the white lists are extracted from http://tools.ietf.org/html/rfc3986 and http://tools.ietf.org/html/rfc6570. The encoding of the fragment is like defined in the global URI rfc 3986 and not like the rfc 6570, because the uri template rfc is not correct here. The whitelist is build from Strings because they are better readable then the arrays used for example in UrlEncoder.
