### PR TITLE
Change MalformedUriTemplate and VariableExpansion exceptions to runtime exceptions

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/MalformedUriTemplateException.java
+++ b/src/main/java/com/damnhandy/uri/template/MalformedUriTemplateException.java
@@ -23,7 +23,7 @@ package com.damnhandy.uri.template;
  * @version $Revision: 1.1 $
  * @since 2.0
  */
-public class MalformedUriTemplateException extends Exception
+public class MalformedUriTemplateException extends RuntimeException
 {
 
    /** The serialVersionUID */

--- a/src/main/java/com/damnhandy/uri/template/VariableExpansionException.java
+++ b/src/main/java/com/damnhandy/uri/template/VariableExpansionException.java
@@ -30,7 +30,7 @@ package com.damnhandy.uri.template;
  * @version $Revision: 1.1 $
  * @since 1.0
  */
-public class VariableExpansionException extends Exception
+public class VariableExpansionException extends RuntimeException
 {
 
    /** The serialVersionUID */


### PR DESCRIPTION
So it's not necessary to wrap in `try` `catch` for programmer error exceptions.
