### PR TITLE
Fix maven-bundle-plugin configuration for OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
 	<groupId>com.damnhandy</groupId>
 	<artifactId>handy-uri-templates</artifactId>
 	<version>2.0.4-SNAPSHOT</version>
+	<packaging>bundle</packaging>
 	<name>Handy URI Templates</name>
     <description>Handy URI Templates is a RFC6570 compliant URI template processor. The library allows clients to utilize templatized URIs and inject replacement variables to expand the template into a URI. The library sports a fluent API, ability to plugin custom object renderers, and supports all levels of URI templates.
     </description>
@@ -168,23 +169,11 @@
 				<version>2.5.4</version>
 				<extensions>true</extensions>
 				<configuration>
-					<archive>
-						<forced>true</forced>
-					</archive>
 					<instructions>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-Name>${project.artifactId}</Bundle-Name>
 					</instructions>
 				</configuration>
-				<executions>
-					<execution>
-						<id>bundle-manifest</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>manifest</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
the `maven-bundle-plugin` was already present in the pom, but did not work - no OSGi metadata was generated to `META-INF/MANIFEST.MF` in the jar file.

this PR fixes and simplifies the `maven-bundle-plugin` configuration.

by default the plugin exports the packages 
* `com.damnhandy.uri.template`
* `com.damnhandy.uri.template.jackson.datatype`

but *not* the package
* `com.damnhandy.uri.template.impl`