### PR TITLE
Replace SimpleDateFormat with Joda Time to Improve Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,5 +466,12 @@
 			<version>4.5</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Date/Time Utilities -->
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.8.2</version>
+		</dependency>
 	</dependencies>
 	</project>

--- a/src/main/java/com/damnhandy/uri/template/UriTemplate.java
+++ b/src/main/java/com/damnhandy/uri/template/UriTemplate.java
@@ -24,6 +24,10 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
 import com.damnhandy.uri.template.impl.Modifier;
 import com.damnhandy.uri.template.impl.Operator;
 import com.damnhandy.uri.template.impl.UriTemplateParser;
@@ -83,7 +87,13 @@ public class UriTemplate implements Serializable
    /**
     *
     */
-   protected DateFormat defaultDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+   DateTimeFormatter defaultDateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+   /**
+    * @deprecated Replaced by {@link #defaultDateTimeFormatter defaultDateTimeFormatter}
+    */
+   @Deprecated
+   protected DateFormat defaultDateFormat = null;
 
    /**
     *
@@ -446,7 +456,13 @@ public class UriTemplate implements Serializable
     */
    public UriTemplate withDefaultDateFormat(String dateFormatString)
    {
-      return this.withDefaultDateFormat(new SimpleDateFormat(dateFormatString));
+      return this.withDefaultDateFormat(DateTimeFormat.forPattern(dateFormatString));
+   }
+
+   private UriTemplate withDefaultDateFormat(DateTimeFormatter dateTimeFormatter)
+   {
+      defaultDateTimeFormatter = dateTimeFormatter;
+      return this;
    }
 
    /**
@@ -454,10 +470,17 @@ public class UriTemplate implements Serializable
     * @param dateFormat
     * @return the date format used to render dates
     * @since 1.0
+    * @deprecated replaced by {@link #withDefaultDateFormat(String) withDefaultDateFormat}
     */
+   @Deprecated
    public UriTemplate withDefaultDateFormat(DateFormat dateFormat)
    {
-      defaultDateFormat = dateFormat;
+      if (!(dateFormat instanceof SimpleDateFormat))
+      {
+         throw new IllegalArgumentException(
+            "The only supported subclass of java.text.DateFormat is java.text.SimpleDateFormat");
+      }
+      defaultDateTimeFormatter = DateTimeFormat.forPattern(((SimpleDateFormat) dateFormat).toPattern());
       return this;
    }
 
@@ -652,7 +675,7 @@ public class UriTemplate implements Serializable
              */
             if (value instanceof Date)
             {
-               value = defaultDateFormat.format((Date) value);
+               value = defaultDateTimeFormatter.print(new DateTime((Date) value));
             }
             /*
              * The variable value contains a list of values

--- a/src/main/java/com/damnhandy/uri/template/UriTemplateBuilder.java
+++ b/src/main/java/com/damnhandy/uri/template/UriTemplateBuilder.java
@@ -9,6 +9,9 @@ import java.text.SimpleDateFormat;
 import java.util.LinkedList;
 import java.util.Map;
 
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
 import com.damnhandy.uri.template.impl.Modifier;
 import com.damnhandy.uri.template.impl.Operator;
 import com.damnhandy.uri.template.impl.UriTemplateParser;
@@ -47,7 +50,7 @@ public final class UriTemplateBuilder
    /**
     *
     */
-   private DateFormat defaultDateFormat = null;
+   private DateTimeFormatter defaultDateTimeFormatter = null;
 
    /**
     *
@@ -78,7 +81,7 @@ public final class UriTemplateBuilder
    {
       this(template.getTemplate());
       this.values = template.getValues();
-      this.defaultDateFormat = template.defaultDateFormat;
+      this.defaultDateTimeFormatter = template.defaultDateTimeFormatter;
    }
 
 
@@ -91,7 +94,13 @@ public final class UriTemplateBuilder
    */
    public UriTemplateBuilder withDefaultDateFormat(String dateFormatString)
    {
-      return this.withDefaultDateFormat(new SimpleDateFormat(dateFormatString));
+      return this.withDefaultDateFormat(DateTimeFormat.forPattern(dateFormatString));
+   }
+
+   private UriTemplateBuilder withDefaultDateFormat(DateTimeFormatter dateTimeFormatter)
+   {
+      defaultDateTimeFormatter = dateTimeFormatter;
+      return this;
    }
 
    /**
@@ -99,10 +108,17 @@ public final class UriTemplateBuilder
     * @param dateFormat
     * @return
     * @since 2.0
+    * @deprecated replaced by {@link #withDefaultDateFormat(String) withDefaultDateFormat}
     */
+   @Deprecated
    public UriTemplateBuilder withDefaultDateFormat(DateFormat dateFormat)
    {
-      defaultDateFormat = dateFormat;
+      if (!(dateFormat instanceof SimpleDateFormat))
+      {
+         throw new IllegalArgumentException(
+            "The only supported subclass of java.text.DateFormat is java.text.SimpleDateFormat");
+      }
+      defaultDateTimeFormatter = DateTimeFormat.forPattern(((SimpleDateFormat) dateFormat).toPattern());
       return this;
    }
 
@@ -525,9 +541,9 @@ public final class UriTemplateBuilder
          template.set(values);
       }
       
-      if (defaultDateFormat != null)
+      if (defaultDateTimeFormatter != null)
       {
-         template.defaultDateFormat = defaultDateFormat;
+         template.defaultDateTimeFormatter = defaultDateTimeFormatter;
       }
       return template;
    }

--- a/src/test/java/com/damnhandy/uri/template/TestUriTemplateBuilder.java
+++ b/src/test/java/com/damnhandy/uri/template/TestUriTemplateBuilder.java
@@ -18,6 +18,8 @@ package com.damnhandy.uri.template;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -98,6 +100,33 @@ public class TestUriTemplateBuilder
                                         .build();
       
       //print(template);
+      template.set("date", date);
+      
+      Assert.assertEquals("http://example.com/foo{/date}", template.getTemplate());
+      Assert.assertEquals("http://example.com/foo/2012-04-20", template.expand());
+   }
+
+   @Test
+   public void testWithSimpleDateFormat() throws Exception
+   {
+      Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("GMT-04:00"));
+      cal.set(Calendar.YEAR, 2012);
+      cal.set(Calendar.MONTH, Calendar.APRIL);
+      cal.set(Calendar.DAY_OF_MONTH, 20);
+      cal.set(Calendar.HOUR_OF_DAY, 16);
+      cal.set(Calendar.MINUTE, 20);
+      cal.set(Calendar.SECOND, 0);
+      cal.set(Calendar.MILLISECOND, 0);
+      Date date = cal.getTime();
+      
+      DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+      
+      UriTemplate template = UriTemplate.buildFromTemplate("http://example.com")
+                                        .withDefaultDateFormat(dateFormat)
+                                        .literal("/foo")
+                                        .path("date")
+                                        .build();
+      
       template.set("date", date);
       
       Assert.assertEquals("http://example.com/foo{/date}", template.getTemplate());

--- a/src/test/java/com/damnhandy/uri/template/TestWithDateFormats.java
+++ b/src/test/java/com/damnhandy/uri/template/TestWithDateFormats.java
@@ -83,6 +83,16 @@ public class TestWithDateFormats
    }
 
    @Test
+   public void testWithSimpleDateFormat() throws Exception
+   {
+      DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+      UriTemplate template = UriTemplate.fromTemplate(TEMPLATE)
+                                        .withDefaultDateFormat(dateFormat)
+                                        .set("date",date);
+      assertEquals("/2012/2012-04-20", template.expand());
+   }
+
+   @Test
    public void testDateRangeQueryString() throws Exception
    {
       Date start = formatDate("2012-04-01T16:20:00.000-0400");


### PR DESCRIPTION
The poor performance of [`java.text.SimpleDateFormat`](http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) is [well documented](https://www.google.com/search?q=SimpleDateFormat+performance). Currently, every instantiation of [`UriTemplate`](https://github.com/damnhandy/Handy-URI-Templates/blob/master/src/main/java/com/damnhandy/uri/template/UriTemplate.java) creates an instance of `SimpleDateFormat`, whether it's needed or not. This pull request replaces the functionality of `SimpleDateFormat` with analogous functionality from [Joda-Time](http://www.joda.org/joda-time/) which improves performance.

Note: A couple of methods and one field that exposed `DateFormat` and `SimpleDateFormat`, and that were part of this library's public interface, were marked as deprecated. I thought it better that the library shouldn't expose the details of its date formatting implementation. Incidentally, the deprecated methods didn't have test coverage (which this PR also adds). The deprecated items should be kept around until the next major version in order to maintain backwards compatibility with existing clients.