### PR TITLE
Fix for building URI templates vars w/ underscores

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/Expression.java
+++ b/src/main/java/com/damnhandy/uri/template/Expression.java
@@ -285,7 +285,6 @@ public class Expression extends UriTemplateComponent
       this.op = op;
       this.varSpecs = varSpecs;
       this.replacementPattern = Pattern.quote(toString());
-      this.matchPattern = buildMatchingPattern();
       this.location = 0;
    }
 

--- a/src/test/java/com/damnhandy/uri/template/builder/TestExpressionBuilder.java
+++ b/src/test/java/com/damnhandy/uri/template/builder/TestExpressionBuilder.java
@@ -107,4 +107,10 @@ public class TestExpressionBuilder
       Expression e = Expression.simple(var("foo", 1), var("bar"), var("thing", true)).build();
       Assert.assertEquals("{foo:1,bar,thing*}", e.toString());
    }
+
+    @Test
+    public void testUnderscorVariableName() throws Exception {
+        Expression e = Expression.query(var("test_var")).build();
+        Assert.assertEquals("{?test_var}", e.toString());
+    }
 }


### PR DESCRIPTION
* Don't eager calculate the match pattern, depend on lazy initalization
  in Expression#getMatchPattern().
* Add test to verify fix.