### PR TITLE
Ad test for https://github.com/damnhandy/Handy-URI-Templates/issues/33

### DIFF
--- a/src/test/java/com/damnhandy/uri/template/impl/TestVarSpec.java
+++ b/src/test/java/com/damnhandy/uri/template/impl/TestVarSpec.java
@@ -1,6 +1,7 @@
 package com.damnhandy.uri.template.impl;
 
 import com.damnhandy.uri.template.UriTemplate;
+import com.damnhandy.uri.template.UriTemplateBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -8,19 +9,19 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static com.damnhandy.uri.template.UriTemplate.buildFromTemplate;
+import static com.damnhandy.uri.template.UriTemplateBuilder.var;
+
 /**
  * Created by ryan on 11/8/15.
  */
-public class TestVarSpec
-{
+public class TestVarSpec {
 
     private static final Map<String, Object> VALUES;
 
-    static
-    {
+    static {
         VALUES = new LinkedHashMap<String, Object>();
-        VALUES.put("experiment", new ArrayList<String>()
-        {
+        VALUES.put("experiment", new ArrayList<String>() {
             {
                 add("one");
                 add("two");
@@ -30,19 +31,47 @@ public class TestVarSpec
     }
 
     @Test
-    public void testWithExplodeModifier() throws Exception
-    {
+    public void testWithExplodeModifier() throws Exception {
         VarSpec varSpec = new VarSpec("experiment*", Modifier.EXPLODE, null);
-        Assert.assertEquals("experiment",varSpec.getVariableName());
+        Assert.assertEquals("experiment", varSpec.getVariableName());
     }
 
     @Test
-    public void testTemplateWithExplodeModifier() throws  Exception
-    {
+    public void testTemplateWithExplodeModifier() throws Exception {
         String templateString = "http://foo.com{/experiment*}";
 
         UriTemplate template = UriTemplate.fromTemplate(templateString);
         String result = template.expand(VALUES);
-        Assert.assertEquals("http://foo.com/one/two/three",result);
+        Assert.assertEquals("http://foo.com/one/two/three", result);
     }
+
+
+    @Test
+    public void createExplodedVarSpecFromUriTemplateBuilder() throws Exception {
+        //when
+        VarSpec varSpec = UriTemplateBuilder.var("experiment", true);
+
+        //then
+        Assert.assertEquals("experiment*", varSpec.getVariableName());
+    }
+
+    @Test
+    public void usingAnUnexpandedExplodedVariableInUriTemplateReturnsAURLContainingTheTemplatedVariable() throws Exception {
+        //when
+        UriTemplate uriTemplate = buildFromTemplate("http://foo.com/").query(var("experiment", true)).build();
+
+        //then
+        Assert.assertEquals("http://foo.com/{?experiment*}", uriTemplate.getTemplate());
+    }
+
+    @Test
+    public void usingAnExpandedExplodedVariableInUriTemplateReturnsAURLContainingTheExpandedVariable() throws Exception {
+        //when
+        UriTemplate uriTemplate = buildFromTemplate("http://foo.com/").query(var("experiment", true)).build();
+
+        //then
+        Assert.assertEquals("http://foo.com/?experiment=expandedExperiment", uriTemplate.set("experiment", "expandedExperiment").expand());
+    }
+
+
 }


### PR DESCRIPTION
Hi,
I added 3 tests (1 succeeding and 2 failing) showing what I mean with issue 33. 

* createExplodedVarSpecFromUriTemplateBuilder:
Javadoc on `com.damnhandy.uri.template.UriTemplateBuilder#var(java.lang.String, boolean)` says you should be able to create an exploded VarSpec using `UriTemplateBuilder.var("experiment", true)` and it should be resolved to `experiment*`

*usingAnUnexpandedExplodedVariableInUriTemplateReturnsAURLContainingTheTemplatedVariable
This test works as expected; a template with an explode variable should result in a templated url like `http://foo.com/{?experiment*}`

* usingAnExpandedExplodedVariableInUriTemplateReturnsAURLContainingTheExpandedVariable
When expanding a template containing an exploded variable, it should be able to resolve the exploded variable.

Best regards
Jan