### PR TITLE
Add UriTemplateBuilder#template to append partial templates.

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/UriTemplate.java
+++ b/src/main/java/com/damnhandy/uri/template/UriTemplate.java
@@ -29,12 +29,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
-import com.damnhandy.uri.template.impl.*;
-
 /**
  * <p>
  * This is the primary class for creating and manipulating URI templates. This project implements
@@ -247,6 +241,15 @@ public class UriTemplate implements Serializable
         return new UriTemplateBuilder(baseTemplate.getTemplate());
     }
 
+    /**
+     * Returns the collection of {@link UriTemplateComponent} instances
+     * found in this template.
+     *
+     * @return
+     */
+    public Collection<UriTemplateComponent> getComponents() {
+        return Collections.unmodifiableCollection(components);
+    }
 
     /**
      * Returns the number of expressions found in this template

--- a/src/main/java/com/damnhandy/uri/template/UriTemplateBuilder.java
+++ b/src/main/java/com/damnhandy/uri/template/UriTemplateBuilder.java
@@ -13,6 +13,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -122,6 +123,11 @@ public final class UriTemplateBuilder
     void addComponent(UriTemplateComponent component)
     {
         this.components.add(component);
+    }
+
+    void addComponents(Collection<UriTemplateComponent> compoments)
+    {
+        this.components.addAll(compoments);
     }
 
     /**
@@ -533,6 +539,67 @@ public final class UriTemplateBuilder
     public UriTemplateBuilder query(VarSpec... var)
     {
         addComponent(Expression.query(var).build());
+        return this;
+    }
+
+    /**
+     * Parses the template and appends the parsed components
+     * to the builder. The following
+     * code:
+     * <pre>
+     * import static com.damnhandy.uri.template.UriTemplateBuilder.var;
+     *
+     * ...
+     *
+     * UriTemplate template =
+     *        UriTemplate.buildFromTemplate("http://example.com/")
+     *                   .template("foo/{id}{?filter}")
+     *                   .build();
+     * </pre>
+     * Will generate the following URI Template string:
+     * <pre>
+     * http://example.com/foo/{id}{?filter}
+     * </pre>
+     *
+     * @param template
+     * @return
+     */
+    public UriTemplateBuilder template(UriTemplate... template) {
+        for(UriTemplate t : template) {
+            addComponents(t.getComponents());
+        }
+
+        return this;
+    }
+
+    /**
+     * Parses the template and appends the parsed components
+     * to the builder. The following
+     * code:
+     * <pre>
+     * import static com.damnhandy.uri.template.UriTemplateBuilder.var;
+     *
+     * ...
+     *
+     * UriTemplate template =
+     *        UriTemplate.buildFromTemplate("http://example.com/")
+     *                   .template("foo/{id}{?filter}")
+     *                   .build();
+     * </pre>
+     * Will generate the following URI Template string:
+     * <pre>
+     * http://example.com/foo/{id}{?filter}
+     * </pre>
+     *
+     * @param template
+     * @return
+     */
+    public UriTemplateBuilder template(String... template) {
+        UriTemplateParser parser = new UriTemplateParser();
+        for(String t : template) {
+            addComponents(parser.scan(t));
+        }
+
         return this;
     }
 

--- a/src/test/java/com/damnhandy/uri/template/TestUriTemplateBuilder.java
+++ b/src/test/java/com/damnhandy/uri/template/TestUriTemplateBuilder.java
@@ -267,6 +267,20 @@ public class TestUriTemplateBuilder
       Assert.assertEquals("http://example.com/{?foo:2}", template.getTemplate());
    }
 
+   @Test
+   public void testTemplateExpression() throws Exception {
+      UriTemplate template = UriTemplate.buildFromTemplate(BASE_URI).template("bar/{id}{?filter}").build();
+
+      Assert.assertEquals("http://example.com/bar/{id}{?filter}", template.getTemplate());
+   }
+
+   @Test
+   public void testTemplateExpressionWithUriTemplate() throws Exception {
+      UriTemplate template = UriTemplate.buildFromTemplate(BASE_URI).template(UriTemplate.fromTemplate("bar/{id}{?filter}")).build();
+
+      Assert.assertEquals("http://example.com/bar/{id}{?filter}", template.getTemplate());
+   }
+
 
     @Test
     public void testCreateNew() throws Exception


### PR DESCRIPTION
* Can pass a template like "foo/{id}{?filter}" to the builder and
  it will add parsed components to the builder.

I am building up a UriTemplate based on the JAX-RS `@Path` annotations, along with inspecting `@QueryParam` method parameters, etc. and in order to easily handle a path like `@Path("/foo/{id}")` (which fortunately *is* a valid RFC URI Template), the following changes are needed.

Thoughts?