### PR TITLE
exposing `continuation` as part of public UriTemplateBuilder api

### DIFF
--- a/src/main/java/com/damnhandy/uri/template/UriTemplateBuilder.java
+++ b/src/main/java/com/damnhandy/uri/template/UriTemplateBuilder.java
@@ -543,6 +543,56 @@ public final class UriTemplateBuilder
     }
 
     /**
+     * Appends a template expression using the form-style query continuation. The following
+     * code:
+     * <pre>
+     * UriTemplate template =
+     *        UriTemplate.buildFromTemplate("http://example.com/")
+     *                   .continuation("foo")
+     *                   .build();
+     * </pre>
+     * Will generate the following URI Template string:
+     * <pre>
+     * http://example.com/{&foo}
+     * </pre>
+     *
+     * @param var
+     * @return
+     */
+    public UriTemplateBuilder continuation(String... var)
+    {
+        return continuation(toVarSpec(var));
+    }
+
+    /**
+     * Appends a template expression using the form-style query continuation and
+     * and optional modifier. The following
+     * code:
+     * <pre>
+     * import static com.damnhandy.uri.template.UriTemplateBuilder.var;
+     *
+     * ...
+     *
+     * UriTemplate template =
+     *        UriTemplate.buildFromTemplate("http://example.com/")
+     *                   .query(var("foo",1))
+     *                   .build();
+     * </pre>
+     * Will generate the following URI Template string:
+     * <pre>
+     * http://example.com/{&foo:1}
+     * </pre>
+     *
+     * @param var
+     * @return
+     */
+    public UriTemplateBuilder continuation(VarSpec... var)
+    {
+        addComponent(Expression.continuation(var).build());
+        return this;
+    }
+
+    /**
      * Parses the template and appends the parsed components
      * to the builder. The following
      * code:

--- a/src/test/java/com/damnhandy/uri/template/TestUriTemplateBuilder.java
+++ b/src/test/java/com/damnhandy/uri/template/TestUriTemplateBuilder.java
@@ -246,6 +246,27 @@ public class TestUriTemplateBuilder
       Assert.assertEquals("http://example.com/{#foo:2}", template.getTemplate());
    }
 
+    @Test
+    public void testQueryContinuation() throws Exception
+    {
+        UriTemplate template = UriTemplate.buildFromTemplate(BASE_URI).continuation("foo").build();
+        Assert.assertEquals("http://example.com/{&foo}", template.getTemplate());
+    }
+
+    @Test
+    public void testQueryContinuationWithExplode() throws Exception
+    {
+        UriTemplate template = UriTemplate.buildFromTemplate(BASE_URI).continuation(var("foo",true)).build();
+        Assert.assertEquals("http://example.com/{&foo*}", template.getTemplate());
+    }
+
+    @Test
+    public void testQueryContinuationWithExplodeAndPre() throws Exception
+    {
+        UriTemplate template = UriTemplate.buildFromTemplate(BASE_URI).continuation(var("foo",2)).build();
+        Assert.assertEquals("http://example.com/{&foo:2}", template.getTemplate());
+    }
+
    @Test
    public void testQueryExpression() throws Exception
    {


### PR DESCRIPTION
Hi, it is a great library, thanks for it.
Today I have plugged it into my project and I notice absence of provided `continuation` functionality (https://tools.ietf.org/html/rfc6570#section-3.2.9).
Please review my pull request