### PR TITLE
starting work on reverse matching

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,24 @@
+challenges
+
+unreserved character encoding lives at the expression level, but we need that
+info to build regex at varspec level
+
+matching of fragment and unreserved characters in list is seemingly impossible
+since `,` is allowed in fragments, but is also the separator token. The RFC seems
+to note this so most likely the solution is to document that we don't support
+values with reserved delimiters
+
+does order need to be considered for key-value paired expressions like ; ? & ifso
+named capture groups cannot be used here
+idea:
+expressions surface two methods, `getMatchPattern()` and `Map getMatches(Matcher)`
+`getMatchPattern` returns a regex to match that expression, but rather than using
+named capture groups which can be used at the top level, the expression uses 
+getMatches to return a map from variable names to values (which can internally use 
+ncg, or not).
+
+ex: `{/var,x}/here{?x,y,empty}` might generate pattern like
+`(?<TWFuIGlzI>(?<var>\/[unreserved]*)(?<x>\/[unreserved]*))\/here(?<GRpc3Rp>\?((x|y|empty)=([unreserved]*)&?){0,3})`
+the expression `{/var,x}` would grab the group `TWFuIGlzI` and use the known group 
+names with ncg to get `var` and `x`, while `{?x,y,empty}` would look at each key value group tuple
+

--- a/src/test/java/com/damnhandy/uri/template/TestMatching.java
+++ b/src/test/java/com/damnhandy/uri/template/TestMatching.java
@@ -1,0 +1,61 @@
+package com.damnhandy.uri.template;
+
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by nfischer on 7/3/2016.
+ */
+public class TestMatching {
+
+    @Test
+    public void test(){
+        Pattern temp1 = UriTemplate.buildFromTemplate("{hello}").build().getReverseMatchPattern();
+        String val1 = "Hello World!";
+        String exp1 = "Hello%20World%21";
+
+        Matcher m = temp1.matcher(exp1);
+        m.find();
+
+        assertEquals(exp1, m.group("hello"));
+        System.out.println(m.group("hello"));
+
+        Pattern temp2 = UriTemplate.buildFromTemplate("{+hello}").build().getReverseMatchPattern();
+        String val2 = "Hello World!";
+        String exp2 = "Hello%20World!";
+        System.out.println(temp2.pattern());
+
+        Matcher m2 = temp2.matcher(exp2);
+        m2.find();
+        System.out.println(m2.group("hello"));
+        assertEquals(exp2, m2.group("hello"));
+
+        Pattern temp3 = UriTemplate.buildFromTemplate("{#x,hello,y}").build().getReverseMatchPattern();
+        String exp3 = "#1024,Hello%20World!,768";
+
+        Matcher m3 = temp3.matcher(exp3);
+        m3.find();
+        System.out.println(m3.group("x"));
+        System.out.println(m3.group("hello"));
+        System.out.println(m3.group("y"));
+        assertEquals("1024", m3.group("x"));
+        assertEquals("Hello%20World!", m3.group("hello"));
+        assertEquals("768", m3.group("y"));
+
+        Pattern temp4 = UriTemplate.buildFromTemplate("{?x,y,empty}").build().getReverseMatchPattern();
+        String exp4 = "?x=1024&y=768&empty=";
+
+        Matcher m4 = temp4.matcher(exp4);
+        m4.find();
+        System.out.println(m4.group("x"));
+        System.out.println(m4.group("empty") + "<(empty)");
+        System.out.println(m4.group("y"));
+        assertEquals("1024", m4.group("x"));
+        assertEquals("", m4.group("empty"));
+        assertEquals("768", m4.group("y"));
+    }
+}


### PR DESCRIPTION
current state is just hacked together POC with some notes

need to integrate with damnhandy test cases

challenges

unreserved character encoding lives at the expression level, but we need that
info to build regex at varspec level

matching of fragment and unreserved characters in list is seemingly impossible
since `,` is allowed in fragments, but is also the separator token. The RFC seems
to note this so most likely the solution is to document that we don't support
values with reserved delimiters

does order need to be considered for key-value paired expressions like ; ? & ifso
named capture groups cannot be used here
idea:
expressions surface two methods, `getMatchPattern()` and `Map getMatches(Matcher)`
`getMatchPattern` returns a regex to match that expression, but rather than using
named capture groups which can be used at the top level, the expression uses 
getMatches to return a map from variable names to values (which can internally use 
ncg, or not).

ex: `{/var,x}/here{?x,y,empty}` might generate pattern like
`(?<TWFuIGlzI>(?<var>\/[unreserved]*)(?<x>\/[unreserved]*))\/here(?<GRpc3Rp>\?((x|y|empty)=([unreserved]*)&?){0,3})`
the expression `{/var,x}` would grab the group `TWFuIGlzI` and use the known group 
names with ncg to get `var` and `x`, while `{?x,y,empty}` would look at each key value group tuple

#2 